### PR TITLE
Add code coverage reporting to CI pipeline

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,5 +10,8 @@
   "settings": {
     "python.pythonPath": "/usr/local/bin/python"
   },
-  "postCreateCommand": "pip install -r requirements.txt && pytest"
+  "postCreateCommand": "pip install -r requirements.txt && pytest --cov=app && coverage report",
+  "tasks": {
+    "build": "pip install -r requirements.txt"
+  }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,15 @@ jobs:
         source venv/bin/activate
         pip install -r requirements.txt
 
-    - name: Run tests
+    - name: Run tests with coverage
       run: |
         source venv/bin/activate
-        pytest
+        pytest --cov=app
+
+    - name: Print coverage report
+      run: |
+        source venv/bin/activate
+        coverage report
 
     - name: Build Docker image
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ psycopg2-binary==2.9.3
 pytest==7.1.2
 Werkzeug==2.0.3
 SQLAlchemy==1.4.47
+pytest-cov==3.0.0


### PR DESCRIPTION
Add code coverage reporting to CI pipeline and development container.

* **requirements.txt**
  - Add `pytest-cov` to the list of dependencies.

* **.github/workflows/ci.yml**
  - Modify the "Run tests" step to include code coverage using `pytest --cov=app`.
  - Add a new step to print the code coverage report using `coverage report`.

* **.devcontainer/devcontainer.json**
  - Modify `postCreateCommand` to run `pytest --cov=app` and print the code coverage report using `coverage report`.
  - Add a `tasks` section with a "build" task to install dependencies.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/arunsanna/fuzzy-lamp/pull/5?shareId=38928e1c-3d95-4379-805e-753775cc4856).